### PR TITLE
Use uids for Craft 3.1 compatibility

### DIFF
--- a/src/controllers/CountController.php
+++ b/src/controllers/CountController.php
@@ -38,9 +38,9 @@ class CountController extends Controller
     {
         $config = Plugin::$plugin->getSettings();
         $request = Craft::$app->getRequest();
-        $slugs = $request->getParam('slugs', []);
+        $uids = $request->getParam('uids', []);
         
-        $counts = Plugin::$plugin->count->getEntriesCount($slugs);
+        $counts = Plugin::$plugin->count->getEntriesCount($uids);
         
         return $this->asJson($counts);
     }
@@ -49,9 +49,9 @@ class CountController extends Controller
     {
         $config = Plugin::$plugin->getSettings();
         $request = Craft::$app->getRequest();
-        $ids = $request->getParam('ids', []);
+        $uids = $request->getParam('uids', []);
         
-        $counts = Plugin::$plugin->count->getCategoriesCount($ids);
+        $counts = Plugin::$plugin->count->getCategoriesCount($uids);
         
         return $this->asJson($counts);
     }
@@ -60,9 +60,9 @@ class CountController extends Controller
     {
         $config = Plugin::$plugin->getSettings();
         $request = Craft::$app->getRequest();
-        $ids = $request->getParam('ids', []);
+        $uids = $request->getParam('uids', []);
         
-        $counts = Plugin::$plugin->count->getUsersCount($ids);
+        $counts = Plugin::$plugin->count->getUsersCount($uids);
         
         return $this->asJson($counts);
     }

--- a/src/resources/cpelementcount.js
+++ b/src/resources/cpelementcount.js
@@ -44,13 +44,13 @@ $(document).ready(function () {
     }
 
     function getEntriesCount() {
-        var slugs = getSectionSlugs();
+        var uids = getSectionUids();
 
-        Craft.postActionRequest('cp-element-count/count/get-entries-count', {slugs: slugs},
+        Craft.postActionRequest('cp-element-count/count/get-entries-count', {uids: uids},
             function (result) {
-                $.each(slugs, function (i, val) {
+                $.each(uids, function (i, val) {
                     if (typeof result[val] !== 'undefined') {
-                        var $anchor = $('#main-content.has-sidebar .sidebar li a[data-handle="' + val + '"]');
+                        var $anchor = $('#main-content.has-sidebar .sidebar li a[data-key="section:' + val + '"]');
                         if ($anchor.length > 0) {
                             addCountToAnchor(result[val], $anchor);
                         }
@@ -69,11 +69,11 @@ $(document).ready(function () {
     }
 
     function getCategoriesCount() {
-        var ids = getGroupIds();
+        var uids = getGroupUids();
 
-        Craft.postActionRequest('cp-element-count/count/get-categories-count', {ids: ids},
+        Craft.postActionRequest('cp-element-count/count/get-categories-count', {uids: uids},
             function (result) {
-                $.each(ids, function (i, val) {
+                $.each(uids, function (i, val) {
                     if (typeof result[val] !== 'undefined') {
                         var $anchor = $('#main-content.has-sidebar .sidebar li a[data-key="group:' + val + '"]');
 
@@ -87,11 +87,11 @@ $(document).ready(function () {
     }
 
     function getUsersCount() {
-        var ids = getGroupIds();
+        var uids = getGroupUids();
 
-        Craft.postActionRequest('cp-element-count/count/get-users-count', {ids: ids},
+        Craft.postActionRequest('cp-element-count/count/get-users-count', {uids: uids},
             function (result) {
-                $.each(ids, function (i, val) {
+                $.each(uids, function (i, val) {
                     if (typeof result[val] !== 'undefined') {
                         var $anchor = $('#main-content.has-sidebar .sidebar li a[data-key="group:' + val + '"]');
 
@@ -122,7 +122,7 @@ $(document).ready(function () {
             function (result) {
                 $.each(folders, function (i, val) {
                     if (typeof result[val] !== 'undefined') {
-                        var $anchor = $('#main-content.has-sidebar .sidebar li a[data-key="folder:' + val.split('|').join('/folder:') + '"]');
+                        var $anchor = $('#main-content.has-sidebar .sidebar li a[data-folder-id="' + val + '"]');
 
                         if ($anchor.length > 0) {
                             addCountToAnchor(result[val], $anchor);                            
@@ -144,38 +144,37 @@ $(document).ready(function () {
         );
     }
 
-    function getSectionSlugs() {
-        var slugs = [];
+    function getSectionUids() {
+        var uids = [];
 
         $('#main-content.has-sidebar .sidebar li a[data-key]').each(function () {
-            if ($(this).data('key').match(/section:\d+/)) {
-                slugs.push($(this).data('handle'));
+            if ($(this).data('key').match(/section:/)) {
+                uids.push($(this).data('key').replace('section:', ''));
             }
         });
 
-        return slugs;
+        return uids;
     }
 
-    function getGroupIds() {
-        var ids = [];
+    function getGroupUids() {
+        var uids = [];
 
         $('#main-content.has-sidebar .sidebar li a[data-key]').each(function () {
-            if ($(this).data('key').match(/group:\d+/)) {
-                ids.push($(this).data('key').replace('group:', ''));
+            if ($(this).data('key').match(/group:/)) {
+                uids.push($(this).data('key').replace('group:', ''));
             }
         });
 
-        return ids;
+        return uids;
     }
 
     function getFolders() {
         var folders = [];
 
-        $('#main-content.has-sidebar .sidebar li a[data-key]').each(function () {
-            if ($(this).data('key').match(/folder:\d+/)) {
-                var folderKeys = $(this).data('key').split('/');
-                folders.push(folderKeys.join('|').replace(/folder:/g, ''));
-            }
+        $('#main-content.has-sidebar .sidebar li a[data-folder-id]').each(function () {
+                var folderKeys = $(this).data('folder-id');
+                folders.push(folderKeys);
+
         });
 
         return folders;

--- a/src/services/CountService.php
+++ b/src/services/CountService.php
@@ -9,11 +9,13 @@
 
 namespace aelvan\cpelementcount\services;
 
+use Craft;
 use craft\base\Component;
 use craft\elements\Asset;
 use craft\elements\Category;
 use craft\elements\Entry;
 use craft\elements\User;
+use craft\services\UserGroups;
 
 /**
  * CpElementCountService Service
@@ -24,17 +26,18 @@ use craft\elements\User;
  */
 class CountService extends Component
 {
-    public function getEntriesCount($slugs = []): array
+    public function getEntriesCount($uids = []): array
     {
-        if (count($slugs) === 0) {
+        if (count($uids) === 0) {
             return [];
         }
 
         $r = [];
 
-        foreach ($slugs as $slug) {
-            $count = Entry::find()->section($slug)->limit(null)->status(['disabled', 'enabled'])->count();
-            $r[$slug] = $count;
+        foreach ($uids as $uid) {
+            $section = Craft::$app->getSections()->getSectionByUid($uid);
+            $count = Entry::find()->sectionId($section->id)->limit(null)->status(['disabled', 'enabled'])->count();
+            $r[$uid] = $count;
         }
 
         $count = Entry::find()->limit(null)->status(['disabled', 'enabled'])->count();
@@ -43,33 +46,34 @@ class CountService extends Component
         return $r;
     }
 
-    public function getCategoriesCount($slugs = []): array
+    public function getCategoriesCount($uids = []): array
     {
-        if (count($slugs) === 0) {
+        if (count($uids) === 0) {
             return [];
         }
 
         $r = [];
 
-        foreach ($slugs as $slug) {
-            $count = Category::find()->groupId($slug)->limit(null)->status(['disabled', 'enabled'])->count();
-            $r[$slug] = $count;
+        foreach ($uids as $uid) {
+            $count = Category::find(['uid' => $uid])->limit(null)->status(['disabled', 'enabled'])->count();
+            $r[$uid] = $count;
         }
 
         return $r;
     }
 
-    public function getUsersCount($ids = []): array
+    public function getUsersCount($uids = []): array
     {
-        if (count($ids) === 0) {
+        if (count($uids) === 0) {
             return [];
         }
 
         $r = [];
 
-        foreach ($ids as $id) {
-            $count = User::find()->groupId($id)->limit(null)->status(null)->count();
-            $r[$id] = $count;
+        foreach ($uids as $uid) {
+            $group = Craft::$app->getUserGroups()->getGroupByUid($uid);
+            $count = User::find()->groupId($group->id)->limit(null)->status(null)->count();
+            $r[$uid] = $count;
         }
         
         $count = User::find()->limit(null)->status(null)->count();


### PR DESCRIPTION
Updated the Entry, Category & User functions to use UIDs instead of IDs.
Assets now use folderIds, which was a bit easier to do than getting the folder UID. ( feel free to change this off course :))

These changes will break the plugin on installs lower than 3.1 so you'll want to up the minimum required Craft version to 3.1 as well.

Cheers
Jan